### PR TITLE
Gateways: Debian Buster

### DIFF
--- a/inventory/gateways
+++ b/inventory/gateways
@@ -1,6 +1,7 @@
 [gateways]
 ingwer.freifunk-mwu.de
 lotuswurzel.freifunk-mwu.de
+mate.freifunk-mwu.de
 uffschnitt.freifunk-mwu.de
 spinat.freifunk-mwu.de
 wasserfloh.freifunk-mwu.de

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -369,6 +369,66 @@ wireguard_networks:
       - gurke
       - morchel
     port: 50064
+  - ipv4: 10.87.253.132/31
+    peers:
+      - mate
+      - ingwer
+    port: 50066
+  - ipv4: 10.87.253.134/31
+    peers:
+      - mate
+      - spinat
+    port: 50067
+  - ipv4: 10.87.253.136/31
+    peers:
+      - mate
+      - uffschnitt
+    port: 50068
+  - ipv4: 10.87.253.138/31
+    peers:
+      - mate
+      - lotuswurzel
+    port: 50069
+  - ipv4: 10.87.253.140/31
+    peers:
+      - mate
+      - wasserfloh
+    port: 50070
+  - ipv4: 10.87.253.142/31
+    peers:
+      - mate
+      - reis
+    port: 50071
+  - ipv4: 10.87.253.144/31
+    peers:
+      - mate
+      - kichererbse
+    port: 50072
+  - ipv4: 10.87.253.146/31
+    peers:
+      - mais
+      - mate
+    port: 50073
+  - ipv4: 10.87.253.148/31
+    peers:
+      - mate
+      - unifi
+    port: 50074
+  - ipv4: 10.87.253.150/31
+    peers:
+      - mate
+      - kumpir
+    port: 50075
+  - ipv4: 10.87.253.152/31
+    peers:
+      - mate
+      - morchel
+    port: 50076
+  - ipv4: 10.87.253.154/31
+    peers:
+      - mate
+      - gurke
+    port: 50077
 
 fastd_groups:
   - gateways

--- a/inventory/host_vars/mate.freifunk-mwu.de
+++ b/inventory/host_vars/mate.freifunk-mwu.de
@@ -1,0 +1,78 @@
+---
+server_type: "gateway"
+
+magic: 111
+
+public_gw_prefixes:
+  - ipv6: 2a03:2260:11a:6f00::/56
+  - ipv6: 2a03:2260:11b:6f00::/56
+
+mesh_gw_prefixes:
+  dom0:
+    ipv4_dhcp: 10.86.12.0/23
+    ipv6_public:
+      - 2a03:2260:11a:6fff::/64
+  dom1:
+    ipv4_dhcp: 10.86.28.0/23
+    ipv6_public:
+      - 2a03:2260:11a:6f01::/64
+  dom2:
+    ipv4_dhcp: 10.86.44.0/23
+    ipv6_public:
+      - 2a03:2260:11a:6f02::/64
+  dom3:
+    ipv4_dhcp: 10.86.60.0/23
+    ipv6_public:
+      - 2a03:2260:11a:6f03::/64
+  dom4:
+    ipv4_dhcp: 10.86.76.0/23
+    ipv6_public:
+      - 2a03:2260:11a:6f04::/64
+  dom5:
+    ipv4_dhcp: 10.86.92.0/23
+    ipv6_public:
+      - 2a03:2260:11a:6f05::/64
+  dom6:
+    ipv4_dhcp: 10.86.108.0/23
+    ipv6_public:
+      - 2a03:2260:11a:6f06::/64
+  dom7:
+    ipv4_dhcp: 10.86.124.0/23
+    ipv6_public:
+      - 2a03:2260:11a:6f07::/64
+  mz:
+    ipv4_dhcp: 10.37.40.0/22
+    ipv6_public:
+      - 2a03:2260:11a:6f00::/64
+  wi:
+    ipv4_dhcp: 10.56.40.0/22
+    ipv6_public:
+      - 2a03:2260:11b:6f00::/64
+
+ffrl_public_ipv4_nat: 185.66.195.35/32
+
+ffrl_exit_server:
+  ffrl-a-ak-ber:
+    public_ipv4_address: 185.66.195.0
+    tunnel_ipv4_network: 100.64.3.252/31
+    tunnel_ipv6_network: 2a03:2260:0:23c::/64
+  ffrl-b-ak-ber:
+    public_ipv4_address: 185.66.195.1
+    tunnel_ipv4_network: 100.64.3.254/31
+    tunnel_ipv6_network: 2a03:2260:0:23d::/64
+  ffrl-a-ix-dus:
+    public_ipv4_address: 185.66.193.0
+    tunnel_ipv4_network: 100.64.4.108/31
+    tunnel_ipv6_network: 2a03:2260:0:23e::/64
+  ffrl-b-ix-dus:
+    public_ipv4_address: 185.66.193.1
+    tunnel_ipv4_network: 100.64.4.110/31
+    tunnel_ipv6_network: 2a03:2260:0:23f::/64
+  ffrl-a-fra2-fra:
+    public_ipv4_address: 185.66.194.0
+    tunnel_ipv4_network: 100.64.4.112/31
+    tunnel_ipv6_network: 2a03:2260:0:240::/64
+  ffrl-b-fra2-fra:
+    public_ipv4_address: 185.66.194.1
+    tunnel_ipv4_network: 100.64.4.114/31
+    tunnel_ipv6_network: 2a03:2260:0:241::/64

--- a/roles/network-iptables-gateway/tasks/main.yml
+++ b/roles/network-iptables-gateway/tasks/main.yml
@@ -12,13 +12,16 @@
     src: nf_conntrack.module.conf.j2
     dest: /etc/modules-load.d/nf_conntrack.conf
 
-- name: load netfilter modules
+- name: load nf_conntrack module
   modprobe:
-    name: "{{ item }}"
+    name: nf_conntrack
     state: present
-  loop:
-    - nf_conntrack
-    - nf_conntrack_ipv4
+
+- name: load nf_conntrack_ipv4 module
+  when: ansible_distribution_major_version|int == 9
+  modprobe:
+    name: nf_conntrack
+    state: present
 
 - name: set netfilter sysctl settings
   sysctl:

--- a/roles/service-dhcpd/handlers/main.yml
+++ b/roles/service-dhcpd/handlers/main.yml
@@ -8,6 +8,11 @@
     name: kea-dhcp4-server
     state: restarted
 
+- name: restart isc-kea-dhcp4-server
+  systemd:
+    name: isc-kea-dhcp4-server
+    state: restarted
+
 - name: restart kea-exporter
   systemd:
     name: kea-exporter

--- a/roles/service-dhcpd/tasks/debian9.yml
+++ b/roles/service-dhcpd/tasks/debian9.yml
@@ -1,0 +1,69 @@
+---
+- name: install dhcp packages
+  package:
+    name: "{{ kea_packages }}"
+    state: present
+
+- name: create systemd override dir for kea-dhcp4-server.service
+  file:
+    path: /etc/systemd/system/kea-dhcp4-server.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: configure systemd unit overrides
+  template:
+    src: kea_dhcp4_server_service_overrides.j2
+    dest: /etc/systemd/system/kea-dhcp4-server.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - reload systemd
+    - restart kea-dhcp4-server
+
+- name: configure kea dhcp server
+  template:
+    src: kea_dhcp4_debian9.conf.j2
+    dest: /etc/kea/kea-dhcp4.conf
+  notify: restart kea-dhcp4-server
+
+- name: remove kea init file if present
+  file:
+    path: /etc/init.d/kea-dhcp4-server
+    state: absent
+  notify: reload systemd
+
+- name: install kea-exporter
+  pip:
+    name: kea-exporter
+    executable: pip3
+    version: 0.3.3
+  notify: restart kea-exporter
+
+- name: create systemd unit for exporter
+  template:
+    src: "kea-exporter.service.j2"
+    dest: "/etc/systemd/system/kea-exporter.service"
+  notify:
+    - reload systemd
+    - restart kea-exporter
+
+- name: write vhost for exporter
+  template:
+    src: kea_exporter_vhost.conf.j2
+    dest: /etc/nginx/conf.d/kea_exporter.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart nginx
+
+- name: enable systemd units
+  systemd:
+    name: "{{ item }}"
+    enabled: yes
+    state: started
+  loop:
+    - kea-dhcp4-server
+    - kea-exporter

--- a/roles/service-dhcpd/tasks/main.yml
+++ b/roles/service-dhcpd/tasks/main.yml
@@ -1,66 +1,9 @@
 ---
-- name: install dhcp packages
-  package:
-    name: "{{ kea_packages }}"
-    state: present
 
-- name: create systemd override dir for kea-dhcp4-server.service
-  file:
-    path: /etc/systemd/system/kea-dhcp4-server.service.d
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
+- name: install Kea from Debain repository
+  include: debian9.yml
+  when: ansible_distribution_major_version|int == 9
 
-- name: configure systemd unit overrides
-  template:
-    src: kea_dhcp4_server_service_overrides.j2
-    dest: /etc/systemd/system/kea-dhcp4-server.service.d/override.conf
-    owner: root
-    group: root
-    mode: 0644
-  notify:
-    - reload systemd
-    - restart kea-dhcp4-server
-
-- name: configure kea dhcp server
-  template:
-    src: kea_dhcp4.conf.j2
-    dest: /etc/kea/kea-dhcp4.conf
-  notify: restart kea-dhcp4-server
-
-- name: remove kea init file if present
-  file:
-    path: /etc/init.d/kea-dhcp4-server
-    state: absent
-  notify: reload systemd
-
-- name: install kea-exporter
-  pip:
-    name: kea-exporter
-    executable: pip3
-  notify: restart kea-exporter
-
-- name: create systemd unit for exporter
-  template:
-    src: "kea-exporter.service.j2"
-    dest: "/etc/systemd/system/kea-exporter.service"
-  notify: reload systemd
-
-- name: write vhost for exporter
-  template:
-    src: kea_exporter_vhost.conf.j2
-    dest: /etc/nginx/conf.d/kea_exporter.conf
-    owner: root
-    group: root
-    mode: 0644
-  notify: restart nginx
-
-- name: enable systemd units
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-    state: started
-  loop:
-    - kea-dhcp4-server
-    - kea-exporter
+- name: install Kea from Upsteam repository
+  include: upstream.yml
+  when: ansible_distribution_major_version|int >= 10

--- a/roles/service-dhcpd/tasks/upstream.yml
+++ b/roles/service-dhcpd/tasks/upstream.yml
@@ -1,0 +1,89 @@
+---
+- name: ensure apt key is present
+  apt_key:
+    state: present
+    id: 1F1564A6
+    url: "https://dl.cloudsmith.io/public/isc/kea-1-6/cfg/gpg/gpg.0607E2621F1564A6.key"
+
+- name: ensure apt repo is present
+  apt_repository:
+    state: present
+    repo: "deb https://dl.cloudsmith.io/public/isc/kea-1-6/deb/debian {{ ansible_distribution_release }} main"
+    update_cache: yes
+    filename: isc-kea
+
+- name: remove old dhcp packages
+  package:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ kea_packages }}"
+
+- name: install dhcp packages
+  package:
+    name: "isc-{{ item }}"
+    state: latest
+  loop: "{{ kea_packages }}"
+
+- name: create systemd override dir for kea-dhcp4-server.service
+  file:
+    path: /etc/systemd/system/isc-kea-dhcp4-server.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: configure systemd unit overrides
+  template:
+    src: kea_dhcp4_server_service_overrides.j2
+    dest: /etc/systemd/system/isc-kea-dhcp4-server.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - reload systemd
+    - restart isc-kea-dhcp4-server
+
+- name: configure kea dhcp server
+  template:
+    src: kea_dhcp4.conf.j2
+    dest: /etc/kea/kea-dhcp4.conf
+  notify: restart isc-kea-dhcp4-server
+
+- name: remove kea init file if present
+  file:
+    path: /etc/init.d/isc-kea-dhcp4-server
+    state: absent
+  notify: reload systemd
+
+- name: install kea-exporter
+  pip:
+    name: kea-exporter
+    state: latest
+    executable: pip3
+  notify: restart kea-exporter
+
+- name: create systemd unit for exporter
+  template:
+    src: "kea-exporter.service.j2"
+    dest: "/etc/systemd/system/kea-exporter.service"
+  notify:
+    - reload systemd
+    - restart kea-exporter
+
+- name: write vhost for exporter
+  template:
+    src: kea_exporter_vhost.conf.j2
+    dest: /etc/nginx/conf.d/kea_exporter.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart nginx
+
+- name: enable systemd units
+  systemd:
+    name: "{{ item }}"
+    enabled: yes
+    state: started
+  loop:
+    - isc-kea-dhcp4-server
+    - kea-exporter

--- a/roles/service-dhcpd/templates/kea-exporter.service.j2
+++ b/roles/service-dhcpd/templates/kea-exporter.service.j2
@@ -7,7 +7,11 @@ After=network.target
 Type=simple
 User=root
 Group=root
+{% if ansible_distribution_major_version|int >= 10 %}
+ExecStart=/usr/local/bin/kea-exporter --address 127.0.0.1 /tmp/kea-dhcp4-ctrl.sock
+{% else %}
 ExecStart=/usr/local/bin/kea-exporter --address 127.0.0.1 /etc/kea/kea-dhcp4.conf
+{% endif %}
 Restart=always
 RestartSec=5s
 

--- a/roles/service-dhcpd/templates/kea_dhcp4_debian9.conf.j2
+++ b/roles/service-dhcpd/templates/kea_dhcp4_debian9.conf.j2
@@ -100,9 +100,12 @@
     },
 {% else %}
     }
+  ]
 {% endif %}
 {% endfor %}
-  ],
+},
+"Logging":
+{
   "loggers": [
     {
       "name": "kea-dhcp4",

--- a/roles/service-fastd-mesh/templates/fastd-limiter.yaml.j2
+++ b/roles/service-fastd-mesh/templates/fastd-limiter.yaml.j2
@@ -11,7 +11,9 @@ key_ttl: 900
 
 gateways:
 {% for gateway in groups['gateways'] %}
+{% if not gateway == 'mate.freifunk-mwu.de' %}
   - {{ gateway.rsplit('.freifunk-mwu.de')[0] }}
+{% endif %}
 {% endfor %}
 
 metrics_url: 'https://%s.freifunk-mwu.de:9281/metrics'


### PR DESCRIPTION
Ich habe unser neues Gateway Mate mit Debian Buster aufgesetzt dafür musste ich ein paar Sachen anpassen.

- Kea Upstream Repo nutzen (keine Kea Pakete mehr in den Debian Buster Repos)
- nf_conntrack_ipv4 entfernen (*_ipv4 und *_ipv6 sind wohl in nf_conntrack integriert worden)
- kea-exporter für Debian Stretch auf Version 0.3.3 fixieren (0.4.0 benötigt mindestens Python 3.6)
