### PR TITLE
Jitsi Nginx Apassungen

### DIFF
--- a/inventory/host_vars/mais.freifunk-mwu.de
+++ b/inventory/host_vars/mais.freifunk-mwu.de
@@ -2,3 +2,5 @@
 server_type: "service"
 
 magic: 128
+
+nginx_default_vhost: False

--- a/inventory/jitsi
+++ b/inventory/jitsi
@@ -1,0 +1,2 @@
+[jitsi]
+mais.freifunk-mwu.de

--- a/roles/service-nginx/defaults/main.yml
+++ b/roles/service-nginx/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 server_names_hash_bucket_size: 64
+nginx_default_vhost: true
 nginx_dhparams: "/etc/nginx/dhparams.pem"

--- a/roles/service-nginx/tasks/main.yml
+++ b/roles/service-nginx/tasks/main.yml
@@ -25,13 +25,19 @@
     path: "{{ nginx_dhparams }}"
     size: 4096
 
-- name: create config snippets directory
+- name: create config directories
   file:
-    path: /etc/nginx/snippets
+    path: "/etc/nginx/{{ item }}"
     state: directory
     mode: 0755
     owner: root
     group: root
+  loop:
+    - modules-available
+    - modules-enabled
+    - sites-available
+    - sites-enabled
+    - snippets
 
 - name: copy gzip.conf to snippets
   copy:

--- a/roles/service-nginx/tasks/main.yml
+++ b/roles/service-nginx/tasks/main.yml
@@ -76,6 +76,7 @@
   notify: restart nginx
 
 - name: write nginx configuration default.conf
+  when: nginx_default_vhost == True
   template:
     src: default.conf.j2
     dest: /etc/nginx/conf.d/default.conf

--- a/roles/service-nginx/templates/nginx.conf.j2
+++ b/roles/service-nginx/templates/nginx.conf.j2
@@ -1,6 +1,8 @@
 user  nginx;
 worker_processes  1;
 
+include /etc/nginx/modules-enabled/*.conf;
+
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
@@ -30,4 +32,5 @@ http {
     gzip  on;
 
     include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
 }

--- a/roles/service-prometheus/templates/prometheus.yml.j2
+++ b/roles/service-prometheus/templates/prometheus.yml.j2
@@ -69,6 +69,19 @@ scrape_configs:
         replacement: '$1'
         target_label: hostname
 
+  - job_name: "jitsi"
+    scheme: "https"
+    static_configs:
+      - targets:
+{% for host in groups['jitsi'] %}
+        - '{{ host }}:9210'
+{% endfor %}
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: '([a-z]+)\..*'
+        replacement: '$1'
+        target_label: hostname
+
 {% for job in ['icmp4','icmp6'] %}
   - job_name: "{{ job }}"
     metrics_path: /probe


### PR DESCRIPTION
Damit Jitsi sich auf unserem Basis Setup installieren lässt musste ich ein paar Änderungen vornehmen.

@freifunk-mwu/admin Gibt es Einwände?

Dabei ist mir auch noch aufgefallen das nginx unter dem User nginx läuft und nicht unter www-data. www-data ist aber bei allen Webseiten Verzeichnissen als Owner gesetzt. Ist das Absicht?