### PR TITLE
Role wireguard: IPv6 Endpoints

### DIFF
--- a/roles/wireguard/templates/wg.conf.j2
+++ b/roles/wireguard/templates/wg.conf.j2
@@ -7,6 +7,6 @@ PrivateKey = {{ wireguard_private_key }}
 ListenPort = {{ item.port }}
 
 [Peer]
-Endpoint = {{ item.remote_hostname }}:{{ item.port }}
+Endpoint = {{ lookup('dig', item.remote_hostname, 'qtype=AAAA') | ipwrap }}:{{ item.port }}
 PublicKey = {{ lookup('passwordstore', 'wireguard/' + item.remote + ' subkey=public') }}
 AllowedIPs = 0.0.0.0/0,::/0


### PR DESCRIPTION
Der Reboot von Servern dauert meist sehr lange weil der Start von ifupdown2 hängt. Das Problem scheint zu sein, dass die anycast bzw. localhost Adresse als DNS-Server in der resolv.conf steht. Da diese aber erst nach dem Start der Wireguard Tunnel (und BIRD) verfügbar ist führt das zu DNS Timeouts die den Start um mehrere Minuten verzögern.

Statt den DNS-Namen könnten wir die Einträge in den Wireguard Configs auf die statischen IPv4/IPv6 Adressen umstellen. Der einzige Nachteil den ich dabei sehe ist, dass kein Fallback auf auf die jeweils anderen IP-Protokollvariante stattfinden würde wenn das gewählte Protokoll bei einem der Hosts mal Probleme machen sollte weil Wireguard nur eine eine Adresse als Endpoint unterstützt.