### PR TITLE
Role certs: ssl_users

### DIFF
--- a/inventory/group_vars/gateways
+++ b/inventory/group_vars/gateways
@@ -26,3 +26,8 @@ prometheus_components:
   - node_exporter
 
 fastd_exporter_opts: '--metrics.perpeer'
+
+ssl_users:
+  - nginx
+  - www-data
+  - stunnel4

--- a/inventory/group_vars/jitsi
+++ b/inventory/group_vars/jitsi
@@ -1,0 +1,6 @@
+---
+ssl_users:
+  - nginx
+  - www-data
+  - prosody
+  - turnserver

--- a/roles/certs/defaults/main.yml
+++ b/roles/certs/defaults/main.yml
@@ -4,3 +4,7 @@ ssl_cert_name: "{{ http_domain_external }}"
 ssl_cert_path: "{{ ssl_directory }}/{{ ssl_cert_name }}/fullchain.pem"
 ssl_key_path: "{{ ssl_directory }}/{{ ssl_cert_name }}/privkey.pem"
 ssl_chain_path: "{{ ssl_directory }}/{{ ssl_cert_name }}/chain.pem"
+
+ssl_users:
+  - nginx
+  - www-data

--- a/roles/certs/tasks/main.yml
+++ b/roles/certs/tasks/main.yml
@@ -4,6 +4,13 @@
     name: ssl-cert
     state: present
 
+- name: add users to ssl-cert group
+  user:
+    name: "{{ item }}"
+    groups: ssl-cert
+    append: yes
+  loop: "{{ ssl_users }}"
+
 - name: Add acme_server to known_hosts
   known_hosts:
     path: /etc/ssh/ssh_known_hosts
@@ -24,8 +31,8 @@
     path: "{{ ssl_directory }}/{{ ssl_cert_name }}"
     state: directory
     mode: 0550
-    owner: www-data
-    group: admin
+    owner: admin
+    group: ssl-cert
 
 - name: create snakeoil cert
   shell: make-ssl-cert generate-default-snakeoil
@@ -38,8 +45,8 @@
     dest: "{{ ssl_key_path }}"
     remote_src: yes
     force: no
-    owner: www-data
-    group: admin
+    owner: admin
+    group: ssl-cert
     mode: 0440
 
 - name: copy snakeoil ssl cert for first start
@@ -48,8 +55,8 @@
     dest: "{{ ssl_cert_path }}"
     remote_src: yes
     force: no
-    owner: www-data
-    group: admin
+    owner: admin
+    group: ssl-cert
     mode: 0440
 
 - name: try to sync ssl certs

--- a/roles/certs/templates/ssl_certs.cron.j2
+++ b/roles/certs/templates/ssl_certs.cron.j2
@@ -12,7 +12,7 @@ for DOMAIN in $DOMAINS; do
 done
 
 #Fix owners
-chown -R www-data:admin $LOCAL_DIR
+chown -R admin:ssl-cert $LOCAL_DIR
 
 #restart
 systemctl reload nginx.service || systemctl start nginx.service


### PR DESCRIPTION
Momentan hat nur der Webserver Zugriff auf die Zertifikate. Um den TURN-Server für Jitsi zu konfigurieren brauchen aber noch andere Dienste Zugriff auf die Zertifikate.